### PR TITLE
Add test step to CI before Docker push

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -36,6 +36,18 @@ jobs:
           echo "Detected version: $VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
+      # --- Run tests ---
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install pytest
+
+      - name: Run tests
+        run: pytest test/
+
       # --- Set up Docker ---
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
Run pytest against the test/ directory after checkout and before building/pushing the Docker image, so a failing test prevents a bad image from being published.

https://claude.ai/code/session_01VrmEY1nCFrho4jXbqt77cJ